### PR TITLE
Add MessagesDelayed  and MessagesNotVisible SQS Attributes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.6.3
+  - 1.15.2
 
 dist: trusty
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.4
+FROM alpine:3.12
 
 RUN  apk add --no-cache --update ca-certificates
 

--- a/main.go
+++ b/main.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"kube-sqs-autoscaler/scale"
-	"kube-sqs-autoscaler/sqs"
+	kubesqs "kube-sqs-autoscaler/sqs"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -26,7 +26,7 @@ var (
 	kubernetesNamespace      string
 )
 
-func Run(p *scale.PodAutoScaler, sqs *sqs.SqsClient) {
+func Run(p *scale.PodAutoScaler, sqs *kubesqs.SqsClient) {
 	ctx := context.Background()
 	lastScaleUpTime := time.Now()
 	lastScaleDownTime := time.Now()
@@ -91,7 +91,7 @@ func main() {
 	flag.Parse()
 
 	p := scale.NewPodAutoScaler(kubernetesDeploymentName, kubernetesNamespace, maxPods, minPods)
-	sqs := sqs.NewSqsClient(sqsQueueUrl, awsRegion)
+	sqs := kubesqs.NewSqsClient(sqsQueueUrl, awsRegion)
 
 	log.Info("Starting kube-sqs-autoscaler")
 	Run(p, sqs)

--- a/main_test.go
+++ b/main_test.go
@@ -23,7 +23,7 @@ func TestRunReachMinReplicas(t *testing.T) {
 	scaleDownCoolPeriod = 1 * time.Second
 	scaleUpCoolPeriod = 1 * time.Second
 	scaleUpMessages = 100
-	scaleDownMessages = 10
+	scaleDownMessages = 3
 	maxPods = 5
 	minPods = 1
 	awsRegion = "us-east-1"
@@ -37,7 +37,12 @@ func TestRunReachMinReplicas(t *testing.T) {
 
 	go Run(p, s)
 
-	Attributes := map[string]*string{"ApproximateNumberOfMessages": aws.String("10")}
+	Attributes := map[string]*string{
+		"ApproximateNumberOfMessages":           aws.String("1"),
+		"ApproximateNumberOfMessagesDelayed":    aws.String("1"),
+		"ApproximateNumberOfMessagesNotVisible": aws.String("1"),
+	}
+
 	input := &sqs.SetQueueAttributesInput{
 		Attributes: Attributes,
 	}
@@ -54,7 +59,7 @@ func TestRunReachMaxReplicas(t *testing.T) {
 	pollInterval = 1 * time.Second
 	scaleDownCoolPeriod = 1 * time.Second
 	scaleUpCoolPeriod = 1 * time.Second
-	scaleUpMessages = 100
+	scaleUpMessages = 300
 	scaleDownMessages = 10
 	maxPods = 5
 	minPods = 1
@@ -69,7 +74,11 @@ func TestRunReachMaxReplicas(t *testing.T) {
 
 	go Run(p, s)
 
-	Attributes := map[string]*string{"ApproximateNumberOfMessages": aws.String("100")}
+	Attributes := map[string]*string{
+		"ApproximateNumberOfMessages":           aws.String("100"),
+		"ApproximateNumberOfMessagesDelayed":    aws.String("100"),
+		"ApproximateNumberOfMessagesNotVisible": aws.String("100"),
+	}
 
 	input := &sqs.SetQueueAttributesInput{
 		Attributes: Attributes,
@@ -86,7 +95,7 @@ func TestRunScaleUpCoolDown(t *testing.T) {
 	pollInterval = 5 * time.Second
 	scaleDownCoolPeriod = 10 * time.Second
 	scaleUpCoolPeriod = 10 * time.Second
-	scaleUpMessages = 100
+	scaleUpMessages = 300
 	scaleDownMessages = 10
 	maxPods = 5
 	minPods = 1
@@ -101,7 +110,11 @@ func TestRunScaleUpCoolDown(t *testing.T) {
 
 	go Run(p, s)
 
-	Attributes := map[string]*string{"ApproximateNumberOfMessages": aws.String("100")}
+	Attributes := map[string]*string{
+		"ApproximateNumberOfMessages":           aws.String("100"),
+		"ApproximateNumberOfMessagesDelayed":    aws.String("100"),
+		"ApproximateNumberOfMessagesNotVisible": aws.String("100"),
+	}
 
 	input := &sqs.SetQueueAttributesInput{
 		Attributes: Attributes,
@@ -119,7 +132,7 @@ func TestRunScaleDownCoolDown(t *testing.T) {
 	scaleDownCoolPeriod = 10 * time.Second
 	scaleUpCoolPeriod = 10 * time.Second
 	scaleUpMessages = 100
-	scaleDownMessages = 10
+	scaleDownMessages = 3
 	maxPods = 5
 	minPods = 1
 	awsRegion = "us-east-1"
@@ -133,7 +146,11 @@ func TestRunScaleDownCoolDown(t *testing.T) {
 
 	go Run(p, s)
 
-	Attributes := map[string]*string{"ApproximateNumberOfMessages": aws.String("10")}
+	Attributes := map[string]*string{
+		"ApproximateNumberOfMessages":           aws.String("1"),
+		"ApproximateNumberOfMessagesDelayed":    aws.String("1"),
+		"ApproximateNumberOfMessagesNotVisible": aws.String("1"),
+	}
 
 	input := &sqs.SetQueueAttributesInput{
 		Attributes: Attributes,
@@ -191,7 +208,11 @@ func (m *MockSQS) SetQueueAttributes(input *sqs.SetQueueAttributesInput) (*sqs.S
 }
 
 func NewMockSqsClient() *kubesqs.SqsClient {
-	Attributes := map[string]*string{"ApproximateNumberOfMessages": aws.String("50")}
+	Attributes := map[string]*string{
+		"ApproximateNumberOfMessages":           aws.String("100"),
+		"ApproximateNumberOfMessagesDelayed":    aws.String("100"),
+		"ApproximateNumberOfMessagesNotVisible": aws.String("100"),
+	}
 
 	return &kubesqs.SqsClient{
 		Client: &MockSQS{

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"kube-sqs-autoscaler/scale"
+	kubesqs "kube-sqs-autoscaler/sqs"
 	"testing"
 	"time"
 
@@ -12,9 +14,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fake "k8s.io/client-go/kubernetes/fake"
-
-	"kube-sqs-autoscaler/scale"
-	mainsqs "kube-sqs-autoscaler/sqs"
 )
 
 func TestRunReachMinReplicas(t *testing.T) {
@@ -191,10 +190,10 @@ func (m *MockSQS) SetQueueAttributes(input *sqs.SetQueueAttributesInput) (*sqs.S
 	return &sqs.SetQueueAttributesOutput{}, nil
 }
 
-func NewMockSqsClient() *mainsqs.SqsClient {
+func NewMockSqsClient() *kubesqs.SqsClient {
 	Attributes := map[string]*string{"ApproximateNumberOfMessages": aws.String("50")}
 
-	return &mainsqs.SqsClient{
+	return &kubesqs.SqsClient{
 		Client: &MockSQS{
 			QueueAttributes: &sqs.GetQueueAttributesOutput{
 				Attributes: Attributes,

--- a/scale/scale.go
+++ b/scale/scale.go
@@ -50,7 +50,8 @@ func (p *PodAutoScaler) ScaleUp(ctx context.Context) error {
 	currentReplicas := deployment.Spec.Replicas
 
 	if *currentReplicas >= int32(p.Max) {
-		return errors.New("Max pods reached")
+		log.Infof("More than max pods running. No scale up. Replicas: %d", *deployment.Spec.Replicas)
+		return nil
 	}
 	nextReplicas := *currentReplicas + int32(1)
 	deployment.Spec.Replicas = &nextReplicas
@@ -73,7 +74,8 @@ func (p *PodAutoScaler) ScaleDown(ctx context.Context) error {
 	currentReplicas := deployment.Spec.Replicas
 
 	if *currentReplicas <= int32(p.Min) {
-		return errors.New("Min pods reached")
+		log.Infof("Less than min pods running. No scale down. Replicas: %d", *deployment.Spec.Replicas)
+		return nil
 	}
 
 	nextReplicas := *currentReplicas - int32(1)

--- a/scale/scale.go
+++ b/scale/scale.go
@@ -2,6 +2,7 @@ package scale
 
 import (
 	"context"
+	"os"
 
 	"github.com/pkg/errors"
 
@@ -13,6 +14,10 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
+var (
+	kubeConfigPath string
+)
+
 type PodAutoScaler struct {
 	Client     typedappv1.DeploymentInterface
 	Max        int
@@ -22,9 +27,10 @@ type PodAutoScaler struct {
 }
 
 func NewPodAutoScaler(kubernetesDeploymentName string, kubernetesNamespace string, max int, min int) *PodAutoScaler {
-	config, err := clientcmd.BuildConfigFromFlags("", "")
+	kubeConfigPath = os.Getenv("KUBE_CONFIG_PATH")
+	config, err := clientcmd.BuildConfigFromFlags("", kubeConfigPath)
 	if err != nil {
-		panic("Failed to configure incluster config")
+		panic("Failed to configure incluster or local config")
 	}
 
 	k8sClient, err := kubernetes.NewForConfig(config)

--- a/scale/scale_test.go
+++ b/scale/scale_test.go
@@ -27,7 +27,7 @@ func TestScaleUp(t *testing.T) {
 	assert.Equal(t, int32(5), *deployment.Spec.Replicas)
 
 	err = p.ScaleUp(ctx)
-	assert.NotNil(t, err)
+	assert.Nil(t, err)
 	deployment, _ = p.Client.Get(ctx, "deploy", metav1.GetOptions{})
 	assert.Equal(t, int32(5), *deployment.Spec.Replicas)
 }
@@ -46,7 +46,7 @@ func TestScaleDown(t *testing.T) {
 	assert.Equal(t, int32(1), *deployment.Spec.Replicas)
 
 	err = p.ScaleDown(ctx)
-	assert.NotNil(t, err)
+	assert.Nil(t, err)
 	deployment, _ = p.Client.Get(ctx, "deploy", metav1.GetOptions{})
 	assert.Equal(t, int32(1), *deployment.Spec.Replicas)
 }

--- a/sqs/sqs.go
+++ b/sqs/sqs.go
@@ -22,7 +22,7 @@ type SqsClient struct {
 }
 
 func NewSqsClient(queue string, region string) *SqsClient {
-	svc := sqs.New(session.New(), &aws.Config{Region: aws.String(region)})
+	svc := sqs.New(session.Must(session.NewSession()), aws.NewConfig().WithRegion(region))
 	return &SqsClient{
 		svc,
 		queue,

--- a/sqs/sqs.go
+++ b/sqs/sqs.go
@@ -31,8 +31,11 @@ func NewSqsClient(queue string, region string) *SqsClient {
 
 func (s *SqsClient) NumMessages() (int, error) {
 	params := &sqs.GetQueueAttributesInput{
-		AttributeNames: []*string{aws.String("ApproximateNumberOfMessages")},
-		QueueUrl:       aws.String(s.QueueUrl),
+		AttributeNames: []*string{
+			aws.String("ApproximateNumberOfMessages"),
+			aws.String("ApproximateNumberOfMessagesDelayed"),
+			aws.String("ApproximateNumberOfMessagesNotVisible")},
+		QueueUrl: aws.String(s.QueueUrl),
 	}
 
 	out, err := s.Client.GetQueueAttributes(params)
@@ -40,10 +43,22 @@ func (s *SqsClient) NumMessages() (int, error) {
 		return 0, errors.Wrap(err, "Failed to get messages in SQS")
 	}
 
-	messages, err := strconv.Atoi(*out.Attributes["ApproximateNumberOfMessages"])
+	approximateNumberOfMessages, err := strconv.Atoi(*out.Attributes["ApproximateNumberOfMessages"])
 	if err != nil {
 		return 0, errors.Wrap(err, "Failed to get number of messages in queue")
 	}
+
+	approximateNumberOfMessagesDelayed, err := strconv.Atoi(*out.Attributes["ApproximateNumberOfMessagesDelayed"])
+	if err != nil {
+		return 0, errors.Wrap(err, "Failed to get number of messages in queue")
+	}
+
+	approximateNumberOfMessagesNotVisible, err := strconv.Atoi(*out.Attributes["ApproximateNumberOfMessagesNotVisible"])
+	if err != nil {
+		return 0, errors.Wrap(err, "Failed to get number of messages in queue")
+	}
+
+	messages := approximateNumberOfMessages + approximateNumberOfMessagesDelayed + approximateNumberOfMessagesNotVisible
 
 	return messages, nil
 }

--- a/sqs/sqs_test.go
+++ b/sqs/sqs_test.go
@@ -12,7 +12,7 @@ func TestNumMessages(t *testing.T) {
 	s := NewMockSqsClient()
 
 	num, err := s.NumMessages()
-	assert.Equal(t, 50, num)
+	assert.Equal(t, 30, num)
 	assert.Nil(t, err)
 }
 
@@ -33,8 +33,11 @@ func (m *MockSQS) SetQueueAttributes(input *sqs.SetQueueAttributesInput) (*sqs.S
 }
 
 func NewMockSqsClient() *SqsClient {
-	Attributes := make(map[string]*string)
-	Attributes["ApproximateNumberOfMessages"] = aws.String("50")
+	Attributes := map[string]*string{
+		"ApproximateNumberOfMessages":           aws.String("10"),
+		"ApproximateNumberOfMessagesDelayed":    aws.String("10"),
+		"ApproximateNumberOfMessagesNotVisible": aws.String("10"),
+	}
 
 	return &SqsClient{
 		Client: &MockSQS{


### PR DESCRIPTION
## Changes

- Add ApproximateNumberOfMessagesDelayed and  in scaling SQS metrics. scale message number is total of ApproximateNumberOfMessagesDelayed, ApproximateNumberOfMessagesNotVisible and ApproximateNumberOfMessages.
- Change to info loglevel in max/min pods.
- Modify deprecated aws session method.